### PR TITLE
docs: Rebrand from "Amber" to "Juanita Amber" and standardize author tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2025-06-13
 
 ### Added
-- Initial release of Amber TimerJob
+- Initial release of Juanita Amber TimerJob
 - Core TimerJob abstract class for creating scheduled jobs
 - ScheduleDirective record for flexible schedule configuration
 - JobContext interface for job execution environment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Amber TimerJob
+# Contributing to Juanita Amber TimerJob
 
-Thank you for considering contributing to Amber TimerJob! We welcome contributions from everyone.
+Thank you for considering contributing to Juanita Amber TimerJob! We welcome contributions from everyone.
 
 ## 🤝 How to Contribute
 
@@ -184,7 +184,7 @@ We follow [Semantic Versioning](https://semver.org/):
 
 ## 📄 License
 
-By contributing to Amber TimerJob, you agree that your contributions will be licensed under the Apache License 2.0.
+By contributing to Juanita Amber TimerJob, you agree that your contributions will be licensed under the Apache License 2.0.
 
 ## 🙋‍♀️ Getting Help
 
@@ -207,4 +207,4 @@ Check our [project roadmap](https://github.com/teppan/amber-timerjob/projects) t
 
 ---
 
-Thank you for contributing to Amber TimerJob! 🚀 
+Thank you for contributing to Juanita Amber TimerJob! 🚀 

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 Amber TimerJob Contributors
+   Copyright 2024 Juanita Amber TimerJob Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Amber TimerJob
+# Juanita Amber TimerJob
 
 [![Maven Central](https://img.shields.io/maven-central/v/net.teppan.amber/amber-timerjob.svg)](https://search.maven.org/artifact/net.teppan.amber/amber-timerjob)
 [![Java Version](https://img.shields.io/badge/Java-17%2B-brightgreen.svg)](https://openjdk.java.net/)
@@ -47,7 +47,7 @@ import java.util.Locale;
 public class MyJob extends TimerJob {
     @Override
     protected void executeJob() throws Exception {
-        getLogger().info("Hello from Amber TimerJob!");
+        getLogger().info("Hello from Juanita Amber TimerJob!");
         // Your business logic here
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>amber-timerjob</artifactId>
   <packaging>jar</packaging>
   <version>1.0.1</version>
-  <name>Amber TimerJob</name>
+      <name>Juanita Amber TimerJob</name>
   <description>A modern, lightweight scheduler library for Java applications</description>
   <url>https://github.com/juanitadevelopment/amber-timerjob</url>
   

--- a/src/main/java/net/teppan/amber/timerjob/CronExpression.java
+++ b/src/main/java/net/teppan/amber/timerjob/CronExpression.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
  * 15,45 * * * * - At 15 and 45 minutes past each hour
  * 
  * @since 1.0
- * @author Amber TimerJob
+ * @author Juanita Development
  */
 public final class CronExpression {
     

--- a/src/main/java/net/teppan/amber/timerjob/JobContext.java
+++ b/src/main/java/net/teppan/amber/timerjob/JobContext.java
@@ -1,9 +1,9 @@
 package net.teppan.amber.timerjob;
 
-import org.slf4j.Logger;
-
 import java.util.Optional;
 import java.util.Properties;
+
+import org.slf4j.Logger;
 
 /**
  * Context interface for TimerJob execution environment.
@@ -12,7 +12,7 @@ import java.util.Properties;
  * execution environment resources needed by TimerJob implementations.</p>
  * 
  * @since 1.0
- * @author Amber TimerJob
+ * @author Juanita Development
  */
 public interface JobContext {
     

--- a/src/main/java/net/teppan/amber/timerjob/ScheduleDirective.java
+++ b/src/main/java/net/teppan/amber/timerjob/ScheduleDirective.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * @param locale locale for execution
  * 
  * @since 1.0
- * @author Amber TimerJob
+ * @author Juanita Development
  */
 public record ScheduleDirective(
     String originalDirective,

--- a/src/main/java/net/teppan/amber/timerjob/ScheduleExecutor.java
+++ b/src/main/java/net/teppan/amber/timerjob/ScheduleExecutor.java
@@ -16,7 +16,7 @@ import java.util.TimerTask;
  * cron-style scheduling.</p>
  * 
  * @since 1.0
- * @author Amber TimerJob
+ * @author Juanita Development
  */
 public final class ScheduleExecutor {
     

--- a/src/main/java/net/teppan/amber/timerjob/SchedulingException.java
+++ b/src/main/java/net/teppan/amber/timerjob/SchedulingException.java
@@ -11,7 +11,7 @@ package net.teppan.amber.timerjob;
  * </ul>
  * 
  * @since 1.0
- * @author Amber TimerJob
+ * @author Juanita Development
  */
 public class SchedulingException extends RuntimeException {
     

--- a/src/main/java/net/teppan/amber/timerjob/TimerJob.java
+++ b/src/main/java/net/teppan/amber/timerjob/TimerJob.java
@@ -1,7 +1,5 @@
 package net.teppan.amber.timerjob;
 
-import org.slf4j.Logger;
-
 import java.time.ZoneId;
 import java.util.Locale;
 import java.util.Optional;
@@ -10,8 +8,10 @@ import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.slf4j.Logger;
+
 /**
- * Abstract base class for all scheduled timer jobs in the Amber TimerJob framework.
+ * Abstract base class for all scheduled timer jobs in the Juanita Amber TimerJob framework.
  * 
  * <p>TimerJob provides a modern, flexible scheduling system that supports various
  * schedule formats including interval-based, time-based, date-based, and cron-style
@@ -63,7 +63,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * }</pre>
  * 
  * @since 1.0
- * @author Amber TimerJob
+ * @author Juanita Development
  */
 public abstract class TimerJob extends TimerTask {
     


### PR DESCRIPTION
## 📝 Changes Made

This PR standardizes the project branding by updating "Amber" references to "Juanita Amber" across documentation and source files.

### Documentation Updates
- **README.md**: Updated title to "Juanita Amber TimerJob" and example messages
- **CONTRIBUTING.md**: Updated all project name references to "Juanita Amber TimerJob"
- **pom.xml**: Updated project name to "Juanita Amber TimerJob" 
- **CHANGELOG.md**: Updated initial release description
- **LICENSE**: Updated copyright to "Juanita Amber TimerJob Contributors"

### Source Code Updates
- **@author tags**: Standardized all Java source files to use "Juanita Development"
- **Class documentation**: Updated TimerJob class description to reference "Juanita Amber TimerJob framework"

### Files Modified (11 total)
- CHANGELOG.md
- CONTRIBUTING.md  
- LICENSE
- README.md
- pom.xml
- src/main/java/net/teppan/amber/timerjob/CronExpression.java
- src/main/java/net/teppan/amber/timerjob/JobContext.java
- src/main/java/net/teppan/amber/timerjob/ScheduleDirective.java
- src/main/java/net/teppan/amber/timerjob/ScheduleExecutor.java
- src/main/java/net/teppan/amber/timerjob/SchedulingException.java
- src/main/java/net/teppan/amber/timerjob/TimerJob.java

## 🔧 Technical Considerations

- **Backward Compatibility**: Package names (`net.teppan.amber.timerjob`), artifact IDs (`amber-timerjob`), and Maven coordinates remain unchanged to maintain compatibility
- **No Breaking Changes**: All technical identifiers and APIs are preserved
- **User-Facing Only**: Changes focus on user-visible branding elements

## ✅ Testing

- All existing functionality remains intact
- No code logic changes made
- Documentation updates only affect presentation